### PR TITLE
ad-personalization option (GDPR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ rewarded_id
 # type bool, default false
 child_directed
 
+# If ads should be personalized. In the European Economic Area, GDPR requires ad personalization to be opt-in.
+# type bool, default true
+is_personalized
+
 # Its value must be "G", "PG", "T" or "MA". If the rating of your app in Play Console and your config of max_ad_content_rate in AdMob are not matched, your app can be banned by Google
 # type String, default G
 max_ad_content_rate 

--- a/admob-lib/admob.gd
+++ b/admob-lib/admob.gd
@@ -23,6 +23,7 @@ export var banner_id:String
 export var interstitial_id:String
 export var rewarded_id:String
 export var child_directed:bool = false
+export var is_personalized:bool = true
 export(String, "G", "PG", "T", "MA") var max_ad_content_rate
 
 # "private" properties
@@ -46,6 +47,11 @@ func child_directed_set(new_val) -> void:
 # warning-ignore:return_value_discarded
 	init()
 
+func is_personalized_set(new_val) -> void:
+	is_personalized = new_val
+# warning-ignore:return_value_discarded
+	init()
+
 func max_ad_content_rate_set(new_val) -> void:
 	if new_val != "G" and new_val != "PG" \
 		and new_val != "T" and new_val != "MA":
@@ -58,7 +64,13 @@ func max_ad_content_rate_set(new_val) -> void:
 func init() -> bool:
 	if(Engine.has_singleton("AdMob")):
 		_admob_singleton = Engine.get_singleton("AdMob")
-		_admob_singleton.initWithContentRating(is_real, get_instance_id(), child_directed, max_ad_content_rate)
+		_admob_singleton.initWithContentRating(
+			is_real,
+			get_instance_id(),
+			child_directed,
+			is_personalized,
+			max_ad_content_rate
+		)
 		return true
 	return false
 	

--- a/admob-plugin/src/GodotAdMob.java
+++ b/admob-plugin/src/GodotAdMob.java
@@ -34,6 +34,7 @@ public class GodotAdMob extends Godot.SingletonBase
 
 	private boolean isReal = false; // Store if is real or not
 	private boolean isForChildDirectedTreatment = false; // Store if is children directed treatment desired
+	private boolean isPersonalized = true; // ads are personalized by default, GDPR compliance within the European Economic Area may require you to disable personalization.
 	private String maxAdContentRating = ""; // Store maxAdContentRating ("G", "PG", "T" or "MA")
 	private Bundle extras = null;
 
@@ -59,7 +60,7 @@ public class GodotAdMob extends Godot.SingletonBase
 	 * @param int gdscript instance id
 	 */
 	public void init(boolean isReal, int instance_id) {
-		this.initWithContentRating(isReal, instance_id, false, "");
+		this.initWithContentRating(isReal, instance_id, false, true, "");
 	}
 
 	/**
@@ -67,18 +68,37 @@ public class GodotAdMob extends Godot.SingletonBase
 	 * @param boolean isReal Tell if the enviroment is for real or test
 	 * @param int gdscript instance id
 	 * @param boolean isForChildDirectedTreatment
+	 * @param boolean isPersonalized If ads should be personalized or not.
+	 *  GDPR compliance within the European Economic Area requires that you
+	 *  disable ad personalization if the user does not wish to opt into
+	 *  ad personalization.
 	 * @param String maxAdContentRating must be "G", "PG", "T" or "MA"
 	 */
-	public void initWithContentRating(boolean isReal, int instance_id, boolean isForChildDirectedTreatment, String maxAdContentRating)
+	public void initWithContentRating(
+		boolean isReal,
+		int instance_id,
+		boolean isForChildDirectedTreatment,
+		boolean isPersonalized,
+		String maxAdContentRating)
 	{
 		this.isReal = isReal;
 		this.instance_id = instance_id;
 		this.isForChildDirectedTreatment = isForChildDirectedTreatment;
+		this.isPersonalized = isPersonalized;
 		this.maxAdContentRating = maxAdContentRating;
 		if (maxAdContentRating != null && maxAdContentRating != "")
 		{
 			extras = new Bundle();
 			extras.putString("max_ad_content_rating", maxAdContentRating);
+		}
+		if(!isPersonalized)
+		{
+			// https://developers.google.com/admob/android/eu-consent#forward_consent_to_the_google_mobile_ads_sdk
+			if(extras == null)
+			{
+				extras = new Bundle();
+			}
+			extras.putString("npa", "1");
 		}
 		Log.d("godot", "AdMob: init with content rating options");
 	}


### PR DESCRIPTION
Hi,

the General Data Protection Regulation (GDPR) within the European Economic Area (EEA) requires that personalization of ads must be opt-in. For this to be possible, there must be an option to control if personalized ads should be loaded.

This PR implements a simple boolean option `is_personalized` that can be set to false to disable ad-personalization. By default ad-personalization is enabled, as is also the case with AdMob.