### PR TITLE
Reimplementing Godot Calls to Signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 *.import
 .import
+.mono
 *.o
 demo/android
 tools/releases

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ show_banner()
 # Hide the banner ad		
 hide_banner()
 
+# Move banner after loaded
+move_banner(on_top: bool)
+
 # Show the interstitial ad
 show_interstitial()
 

--- a/admob-plugin/godotadmob/src/main/java/shinnil/godot/plugin/android/godotadmob/Banner.java
+++ b/admob-plugin/godotadmob/src/main/java/shinnil/godot/plugin/android/godotadmob/Banner.java
@@ -33,20 +33,8 @@ public class Banner {
         this.layout = layout;
         this.adRequest = adRequest;
         this.defaultBannerListener = defaultBannerListener;
-        adParams = new FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.WRAP_CONTENT
-        );
-        if (isOnTop) adParams.gravity = Gravity.TOP;
-        else adParams.gravity = Gravity.BOTTOM;
-
-        adView = new AdView(activity);
-        adView.setAdUnitId(id);
-
-        adView.setBackgroundColor(Color.TRANSPARENT);
-
-        adView.setAdSize(AdSize.SMART_BANNER);
-        adView.setAdListener(new AdListener() {
+                
+        AddBanner(id, (isOnTop ? Gravity.TOP : Gravity.BOTTOM), AdSize.SMART_BANNER, new AdListener() {
             @Override
             public void onAdLoaded() {
                 Log.w("godot", "AdMob: onAdLoaded");
@@ -59,11 +47,6 @@ public class Banner {
                 defaultBannerListener.onBannerFailedToLoad(errorCode);
             }
         });
-        layout.addView(adView, adParams);
-
-        // Request
-        adView.loadAd(adRequest);
-
     }
 
     public void show() {
@@ -83,9 +66,17 @@ public class Banner {
 
     public void move(final boolean isOnTop)
     {
-        if (isOnTop) adParams.gravity = Gravity.TOP;
-        else adParams.gravity = Gravity.BOTTOM;
-        resize();
+        if (layout == null || adView == null || adParams == null) {
+            return;
+        }
+
+        layout.removeView(adView); // Remove the old view
+
+        AdListener adListener = adView.getAdListener();
+        String id = adView.getAdUnitId();
+        AddBanner(id, (isOnTop ? Gravity.TOP : Gravity.BOTTOM), adView.getAdSize(), adListener);
+
+        Log.d("godot", "AdMob: Banner Moved");
     }
 
     public void resize() {
@@ -95,32 +86,32 @@ public class Banner {
 
         layout.removeView(adView); // Remove the old view
 
-        // Extract params
+        AdListener adListener = adView.getAdListener();
+        String id = adView.getAdUnitId();
+        AddBanner(id, adParams.gravity, getAdSize(), adListener);
 
-        int gravity = adParams.gravity;
+        Log.d("godot", "AdMob: Banner Resized");
+    }
+
+    private void AddBanner(final String id, final int gravity, final AdSize size, final AdListener listener) {
         adParams = new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
                 FrameLayout.LayoutParams.WRAP_CONTENT
         );
         adParams.gravity = gravity;
-        AdListener adListener = adView.getAdListener();
-        String id = adView.getAdUnitId();
-
+        
         // Create new view & set old params
         adView = new AdView(activity);
         adView.setAdUnitId(id);
         adView.setBackgroundColor(Color.TRANSPARENT);
-        AdSize adSize = getAdSize();
-        adView.setAdSize(adSize);
-        adView.setAdListener(adListener);
+        adView.setAdSize(size);
+        adView.setAdListener(listener);
 
         // Add to layout and load ad
         layout.addView(adView, adParams);
 
         // Request
         adView.loadAd(adRequest);
-
-        Log.d("godot", "AdMob: Banner Resized");
     }
 
     public void remove() {

--- a/admob-plugin/godotadmob/src/main/java/shinnil/godot/plugin/android/godotadmob/Interstitial.java
+++ b/admob-plugin/godotadmob/src/main/java/shinnil/godot/plugin/android/godotadmob/Interstitial.java
@@ -7,42 +7,52 @@ import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.InterstitialAd;
 
-import org.godotengine.godot.GodotLib;
+interface InterstitialListener {
+    void onInterstitialLoaded();
+    void onInterstitialFailedToLoad(int errorCode);
+    void onInterstitialOpened();
+    void onInterstitialLeftApplication();
+    void onInterstitialClosed();
+}
 
 public class Interstitial {
     private InterstitialAd interstitialAd = null; // Interstitial object
+    private InterstitialListener defaultInterstitialListener;
 
-    public Interstitial(final String id, final AdRequest adRequest, final Activity activity, final int instanceId) {
+    public Interstitial(final String id, final AdRequest adRequest, final Activity activity, final InterstitialListener defaultInterstitialListener) {
+        this.defaultInterstitialListener = defaultInterstitialListener;
         interstitialAd = new InterstitialAd(activity);
         interstitialAd.setAdUnitId(id);
         interstitialAd.setAdListener(new AdListener() {
             @Override
             public void onAdLoaded() {
                 Log.w("godot", "AdMob: onAdLoaded");
-                GodotLib.calldeferred(instanceId, "_on_interstitial_loaded", new Object[]{});
+                defaultInterstitialListener.onInterstitialLoaded();
             }
 
             @Override
             public void onAdFailedToLoad(int errorCode) {
                 Log.w("godot", "AdMob: onAdFailedToLoad(int errorCode) - error code: " + Integer.toString(errorCode));
-                GodotLib.calldeferred(instanceId, "_on_interstitial_failed_to_load", new Object[]{errorCode});
+                defaultInterstitialListener.onInterstitialFailedToLoad(errorCode);
             }
 
             @Override
             public void onAdOpened() {
                 Log.w("godot", "AdMob: onAdOpened()");
+                defaultInterstitialListener.onInterstitialOpened();
             }
 
             @Override
             public void onAdLeftApplication() {
                 Log.w("godot", "AdMob: onAdLeftApplication()");
+                defaultInterstitialListener.onInterstitialLeftApplication();
             }
 
             @Override
             public void onAdClosed() {
-                GodotLib.calldeferred(instanceId, "_on_interstitial_close", new Object[]{});
                 interstitialAd.loadAd(adRequest);
                 Log.w("godot", "AdMob: onAdClosed");
+                defaultInterstitialListener.onInterstitialClosed();
             }
         });
 

--- a/admob-plugin/godotadmob/src/main/java/shinnil/godot/plugin/android/godotadmob/RewardedVideo.java
+++ b/admob-plugin/godotadmob/src/main/java/shinnil/godot/plugin/android/godotadmob/RewardedVideo.java
@@ -9,64 +9,71 @@ import com.google.android.gms.ads.reward.RewardItem;
 import com.google.android.gms.ads.reward.RewardedVideoAd;
 import com.google.android.gms.ads.reward.RewardedVideoAdListener;
 
-import org.godotengine.godot.GodotLib;
-
+interface RewardedVideoListener {
+    void onRewardedVideoLoaded();
+    void onRewardedVideoFailedToLoad(int errorCode);
+    void onRewardedVideoLeftApplication();
+    void onRewardedVideoOpened();
+    void onRewardedVideoClosed();
+    void onRewarded(String type, int amount);
+    void onRewardedVideoStarted();
+    void onRewardedVideoCompleted();
+}
 
 public class RewardedVideo {
     private RewardedVideoAd rewardedVideoAd = null;
 
-    public RewardedVideo(Activity activity, final int instanceId) {
+    public RewardedVideo(Activity activity, final RewardedVideoListener defaultRewardedVideoListener) {
         MobileAds.initialize(activity);
         rewardedVideoAd = MobileAds.getRewardedVideoAdInstance(activity);
         rewardedVideoAd.setRewardedVideoAdListener(new RewardedVideoAdListener() {
             @Override
-            public void onRewardedVideoAdLeftApplication() {
-                Log.w("godot", "AdMob: onRewardedVideoAdLeftApplication");
-                GodotLib.calldeferred(instanceId, "_on_rewarded_video_ad_left_application", new Object[]{});
-            }
-
-            @Override
-            public void onRewardedVideoAdClosed() {
-                Log.w("godot", "AdMob: onRewardedVideoAdClosed");
-                GodotLib.calldeferred(instanceId, "_on_rewarded_video_ad_closed", new Object[]{});
+            public void onRewardedVideoAdLoaded() {
+                Log.w("godot", "AdMob: onRewardedVideoAdLoaded");
+                defaultRewardedVideoListener.onRewardedVideoLoaded();
             }
 
             @Override
             public void onRewardedVideoAdFailedToLoad(int errorCode) {
                 Log.w("godot", "AdMob: onRewardedVideoAdFailedToLoad. errorCode: " + errorCode);
-                GodotLib.calldeferred(instanceId, "_on_rewarded_video_ad_failed_to_load", new Object[]{errorCode});
+                defaultRewardedVideoListener.onRewardedVideoFailedToLoad(errorCode);
             }
 
             @Override
-            public void onRewardedVideoAdLoaded() {
-                Log.w("godot", "AdMob: onRewardedVideoAdLoaded");
-                GodotLib.calldeferred(instanceId, "_on_rewarded_video_ad_loaded", new Object[]{});
+            public void onRewardedVideoAdLeftApplication() {
+                Log.w("godot", "AdMob: onRewardedVideoAdLeftApplication");
+                defaultRewardedVideoListener.onRewardedVideoLeftApplication();
             }
 
             @Override
             public void onRewardedVideoAdOpened() {
                 Log.w("godot", "AdMob: onRewardedVideoAdOpened");
-                GodotLib.calldeferred(instanceId, "_on_rewarded_video_ad_opened", new Object[]{});
+                defaultRewardedVideoListener.onRewardedVideoOpened();
+            }
+
+            @Override
+            public void onRewardedVideoAdClosed() {
+                Log.w("godot", "AdMob: onRewardedVideoAdClosed");
+                defaultRewardedVideoListener.onRewardedVideoClosed();
             }
 
             @Override
             public void onRewarded(RewardItem reward) {
                 Log.w("godot", "AdMob: "
                         + String.format(" onRewarded! currency: %s amount: %d", reward.getType(), reward.getAmount()));
-                GodotLib.calldeferred(instanceId, "_on_rewarded",
-                        new Object[]{reward.getType(), reward.getAmount()});
+                defaultRewardedVideoListener.onRewarded(reward.getType(), reward.getAmount());
             }
 
             @Override
             public void onRewardedVideoStarted() {
                 Log.w("godot", "AdMob: onRewardedVideoStarted");
-                GodotLib.calldeferred(instanceId, "_on_rewarded_video_started", new Object[]{});
+                defaultRewardedVideoListener.onRewardedVideoStarted();
             }
 
             @Override
             public void onRewardedVideoCompleted() {
                 Log.w("godot", "AdMob: onRewardedVideoCompleted");
-                GodotLib.calldeferred(instanceId, "_on_rewarded_video_completed", new Object[]{});
+                defaultRewardedVideoListener.onRewardedVideoCompleted();
             }
         });
     }

--- a/demo/admob-lib/admob.gd
+++ b/demo/admob-lib/admob.gd
@@ -64,9 +64,22 @@ func max_ad_content_rate_set(new_val) -> void:
 func init() -> bool:
 	if(Engine.has_singleton("GodotAdMob")):
 		_admob_singleton = Engine.get_singleton("GodotAdMob")
+
+		_admob_singleton.connect("on_admob_ad_loaded", self, "_on_admob_ad_loaded");
+		_admob_singleton.connect("on_admob_banner_failed_to_load", self, "_on_admob_banner_failed_to_load");
+		_admob_singleton.connect("on_interstitial_failed_to_load", self, "_on_interstitial_failed_to_load");
+		_admob_singleton.connect("on_interstitial_loaded", self, "_on_interstitial_loaded");
+		_admob_singleton.connect("on_interstitial_close", self, "_on_interstitial_close");
+		_admob_singleton.connect("on_rewarded_video_ad_loaded", self, "_on_rewarded_video_ad_loaded");
+		_admob_singleton.connect("on_rewarded_video_ad_closed", self, "_on_rewarded_video_ad_closed");
+		_admob_singleton.connect("on_rewarded", self, "_on_rewarded");
+		_admob_singleton.connect("on_rewarded_video_ad_left_application", self, "_on_rewarded_video_ad_left_application");
+		_admob_singleton.connect("on_rewarded_video_ad_failed_to_load", self, "_on_rewarded_video_ad_failed_to_load");
+		_admob_singleton.connect("on_rewarded_video_ad_opened", self, "_on_rewarded_video_ad_opened");
+		_admob_singleton.connect("on_rewarded_video_started", self, "_on_rewarded_video_started");
+
 		_admob_singleton.initWithContentRating(
 			is_real,
-			get_instance_id(),
 			child_directed,
 			is_personalized,
 			max_ad_content_rate
@@ -107,6 +120,11 @@ func show_banner() -> void:
 func hide_banner() -> void:
 	if _admob_singleton != null:
 		_admob_singleton.hideBanner()
+
+func move_banner(on_top: bool) -> void:
+	if _admob_singleton != null:
+		banner_on_top = on_top
+		_admob_singleton.move(banner_on_top)
 
 func show_interstitial() -> void:
 	if _admob_singleton != null:

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -4,16 +4,31 @@ onready var admob = $AdMob
 onready var debug_out = $CanvasLayer/DebugOut
 
 func _ready():
-	admob.load_banner()
-	admob.load_interstitial()
-	admob.load_rewarded_video()
+	loadAds()
 # warning-ignore:return_value_discarded
 	get_tree().connect("screen_resized", self, "_on_resize")
 
+func loadAds() -> void:
+	admob.load_banner()
+	admob.load_interstitial()
+	admob.load_rewarded_video()
+
 # buttons callbacks
+func _on_BtnReload_pressed() -> void:
+	loadAds()
+	
 func _on_BtnBanner_toggled(button_pressed):
 		if button_pressed: admob.show_banner()
 		else: admob.hide_banner()
+
+func _on_BtnBannerMove_toggled(button_pressed: bool) -> void:
+	admob.move_banner(button_pressed)
+	$"CanvasLayer/BtnBannerResize".disabled = true
+	$"CanvasLayer/BtnBanner".disabled = true
+	$"CanvasLayer/BtnBannerMove".disabled = true
+
+func _on_BtnBannerResize_pressed() -> void:
+	admob.banner_resize()
 
 func _on_BtnInterstitial_pressed():
 	debug_out.text = debug_out.text + "Interstitial loaded before shown = " + str(admob.is_interstitial_loaded()) +"\n"
@@ -34,7 +49,9 @@ func _on_AdMob_banner_failed_to_load(error_code):
 	debug_out.text = debug_out.text + "Banner failed to load: Error code " + str(error_code) + "\n"
 
 func _on_AdMob_banner_loaded():
+	$"CanvasLayer/BtnBannerResize".disabled = false
 	$"CanvasLayer/BtnBanner".disabled = false
+	$"CanvasLayer/BtnBannerMove".disabled = false
 	debug_out.text = debug_out.text + "Banner loaded\n"
 	debug_out.text = debug_out.text + "Banner size = " + str(admob.get_banner_dimension()) +  "\n"
 

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -27,6 +27,50 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="BtnReload" type="Button" parent="CanvasLayer"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -291.0
+margin_top = -217.0
+margin_right = -213.0
+margin_bottom = -142.0
+text = "Reload"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="BtnInterstitial" type="Button" parent="CanvasLayer"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -75.0
+margin_top = -166.077
+margin_right = 75.0
+margin_bottom = -91.0766
+disabled = true
+text = "Show Interstitial"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="BtnBannerResize" type="Button" parent="CanvasLayer"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -251.0
+margin_top = -65.6294
+margin_right = -101.0
+margin_bottom = 9.37061
+disabled = true
+text = "Resize Banner"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [node name="BtnBanner" type="Button" parent="CanvasLayer"]
 anchor_left = 0.5
 anchor_top = 0.5
@@ -43,17 +87,18 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="BtnInterstitial" type="Button" parent="CanvasLayer"]
+[node name="BtnBannerMove" type="Button" parent="CanvasLayer"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = -75.0
-margin_top = -166.077
-margin_right = 75.0
-margin_bottom = -91.0766
+margin_left = 103.0
+margin_top = -65.6294
+margin_right = 253.0
+margin_bottom = 9.37061
 disabled = true
-text = "Show Interstitial"
+toggle_mode = true
+text = "Move Banner"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -81,9 +126,13 @@ __meta__ = {
 banner_id = "ca-app-pub-3940256099942544/6300978111"
 interstitial_id = "ca-app-pub-3940256099942544/1033173712"
 rewarded_id = "ca-app-pub-3940256099942544/5224354917"
+is_personalized = false
 max_ad_content_rate = "G"
-[connection signal="toggled" from="CanvasLayer/BtnBanner" to="." method="_on_BtnBanner_toggled"]
+[connection signal="pressed" from="CanvasLayer/BtnReload" to="." method="_on_BtnReload_pressed"]
 [connection signal="pressed" from="CanvasLayer/BtnInterstitial" to="." method="_on_BtnInterstitial_pressed"]
+[connection signal="pressed" from="CanvasLayer/BtnBannerResize" to="." method="_on_BtnBannerResize_pressed"]
+[connection signal="toggled" from="CanvasLayer/BtnBanner" to="." method="_on_BtnBanner_toggled"]
+[connection signal="toggled" from="CanvasLayer/BtnBannerMove" to="." method="_on_BtnBannerMove_toggled"]
 [connection signal="pressed" from="CanvasLayer/BtnRewardedVideo" to="." method="_on_BtnRewardedVideo_pressed"]
 [connection signal="banner_failed_to_load" from="AdMob" to="." method="_on_AdMob_banner_failed_to_load"]
 [connection signal="banner_loaded" from="AdMob" to="." method="_on_AdMob_banner_loaded"]


### PR DESCRIPTION
I have changed the implementation from GodotLib.calldeferred to emitSignal like it was used with GodotGooglePaymentBilling,

I also added a new method called _move_ which I can update the banner position without the need to load it again. I also changed a bit the implementation of the Banner because I was copying and pasting a lot and it was being hard to maintain, one point I would like to state is that the _resize_ method has a different implementation so I took care to keep it the way it was.

I update the demo project and added the new methods to the README.md.

I tested it a lot so it is working very well for me.