### PR TITLE
Clarifying the AndroidManifest.xml file change location

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ Currently, this plugin supports:
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="ca-app-pub-3940256099942544~3347511713"/>
 ```
-One good place to add this metadata is just below these lines:
+One good place to add this metadata is just below these lines, inside of the **application** tag:
 ```
+<application>
+...
 <!-- Custom application XML added by add-ons. -->
 <!--CHUNK_APPLICATION_BEGIN-->
 <!--CHUNK_APPLICATION_END-->
+
+Here
+</application>
 ```
 
 **NOTE**: everytime you install a new version of the Android Build Template this step must be done again, as the ```AndroidManifest.xml``` file will be overriden.


### PR DESCRIPTION
Hi @Shin-NiL,

I just wanted to add that line to Clarify a bit more on the readme, where most people follow, where those three lines are. Because I made the mistake of putting it in the wrong location in AndroidManifest.xml file at first and then went to the link and found out my mistake. So this could help a bit more at first sight.