### PR TITLE
Add Function to Initialize AdMob in Background

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ testing_consent
 ### Methods
 ```python
 
+# Initialize AdMob on a background thread for optimization
+initialize_on_background_thread()
+
 # Load the banner (and show inmediatly)
 load_banner()
 
@@ -204,6 +207,9 @@ reset_consent()
 ```
 ### Signals
 ```python
+# AdMob Background Initialization Success
+admob_initialized
+
 # Banner ad was loaded with success
 banner_loaded
 
@@ -313,6 +319,19 @@ adb logcat -s godot
 * Any other error code: you can find more information about the error codes [here](https://support.google.com/admob/thread/3494603). Please don't open issues on this repository asking for help about that, as we can't provide any, sorry.
 
 * Banner sizes: [Adaptive Banners](https://developers.google.com/admob/android/banner/adaptive) and [Smart Banners](https://developers.google.com/admob/android/banner/smart) uses dynamic banner sizes, the [other options](https://developers.google.com/admob/android/banner) uses fixed sizes, please check its respectives documentation for more details. Smart banners are deprecated and may not work properly.
+
+## Optimize AdMob
+
+To prevent ["Application Not Responding" (ANR)](https://developer.android.com/topic/performance/vitals/anr) issues, you can follow some of the optimization strategies mentioned below.
+
+Before making any method calls to load ads, call `initialize_on_background_thread()` to initialize AdMob. The signal `admob_initialized` will be triggered, indicating that the initialization was successful.
+
+Alternatively, you can update your manifest with the optimization flag `OPTIMIZE_INITIALIZATION` to improve initialization without using a background thread.
+
+You can also use the `OPTIMIZE_AD_LOADING` flag to improve ad loading performance.
+
+Learn more at [Optimize initialization and ad loading (Beta)](https://developers.google.com/admob/android/optimize-initialization).
+
 
 ## References
 

--- a/admob-lib/admob.gd
+++ b/admob-lib/admob.gd
@@ -3,6 +3,8 @@ extends Node
 class_name AdMob, "res://admob-lib/icon.png"
 
 # signals
+signal admob_initialized
+
 signal banner_loaded
 signal banner_failed_to_load(error_code)
 signal interstitial_failed_to_load(error_code)
@@ -111,6 +113,8 @@ func init() -> bool:
 
 # connect the AdMob Java signals
 func connect_signals() -> void:
+	_admob_singleton.connect("on_admob_initialized", self, "_on_admob_initialized")
+
 	_admob_singleton.connect("on_admob_ad_loaded", self, "_on_admob_ad_loaded")
 	_admob_singleton.connect("on_admob_banner_failed_to_load", self, "_on_admob_banner_failed_to_load")
 	_admob_singleton.connect("on_interstitial_failed_to_load", self, "_on_interstitial_failed_to_load")
@@ -135,6 +139,12 @@ func connect_signals() -> void:
 	_admob_singleton.connect("on_consent_info_update_success", self, "_on_consent_info_update_success")
 	_admob_singleton.connect("on_consent_info_update_failure", self, "_on_consent_info_update_failure")
 	_admob_singleton.connect("on_app_can_request_ads", self, "_on_app_can_request_ads")
+
+
+# initialize
+func initialize_on_background_thread() -> void:
+	if _admob_singleton != null:
+		_admob_singleton.initializeOnBackgroundThread()
 
 # load
 
@@ -220,6 +230,9 @@ func reset_consent() -> void:
 		_admob_singleton.resetConsentInformation()
 
 # callbacks
+
+func _on_admob_initialized() -> void:
+	emit_signal("admob_initialized")
 
 func _on_admob_ad_loaded() -> void:
 	emit_signal("banner_loaded")

--- a/admob-plugin/godotadmob/src/main/java/shinnil/godot/plugin/android/godotadmob/GodotAdMob.java
+++ b/admob-plugin/godotadmob/src/main/java/shinnil/godot/plugin/android/godotadmob/GodotAdMob.java
@@ -17,6 +17,8 @@ import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
+import com.google.android.gms.ads.initialization.InitializationStatus;
+import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
 
 import org.godotengine.godot.Godot;
 import org.godotengine.godot.GodotLib;
@@ -72,6 +74,8 @@ public class GodotAdMob extends GodotPlugin {
     @Override
     public Set<SignalInfo> getPluginSignals() {
         Set<SignalInfo> signals = new ArraySet<>();
+
+        signals.add(new SignalInfo("on_admob_initialized"));
 
         signals.add(new SignalInfo("on_admob_ad_loaded"));
         signals.add(new SignalInfo("on_admob_banner_failed_to_load", Integer.class));
@@ -201,6 +205,21 @@ public class GodotAdMob extends GodotPlugin {
 
         adRequest = adBuilder.build();
         return adRequest;
+    }
+
+    /**
+     * To Initializes AdMob on a background thread to improve performance.
+     */
+    @UsedByGodot
+    public void initializeOnBackgroundThread() {
+        new Thread(() -> {
+            MobileAds.initialize(activity, new OnInitializationCompleteListener() {
+                @Override
+                public void onInitializationComplete(InitializationStatus initializationStatus) {
+                    emitSignal("on_admob_initialized");
+                }
+            });
+        }).start();
     }
 
     /* Rewarded Video


### PR DESCRIPTION
The `initialize_on_background_thread()` function is added to initialize AdMob on a background thread. I experienced a few ANRs on some low-end devices, and using background initialization along with the `OPTIMIZE_AD_LOADING` flag significantly improved responsiveness on my test device.

- Added `initialize_on_background_thread()` to handle AdMob initialization in the background.
- Emitted the `admob_initialized` signal upon successful initialization.
- Updated the readme to include optimization flags `OPTIMIZE_INITIALIZATION` and `OPTIMIZE_AD_LOADING`.

Official docs:
- https://developers.google.com/admob/android/optimize-initialization
- https://developers.google.com/admob/android/quick-start#initialize_the_mobile_ads_sdk
